### PR TITLE
Fix commands matching reserved string names

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	// Version is the current version of rcsm
-	Version string = "0.0.1"
+	Version string = "0.0.2"
 	// EnvFile is the path to the .env file config
 	EnvFile string = ".env"
 

--- a/src/tmux/tmux.go
+++ b/src/tmux/tmux.go
@@ -76,7 +76,15 @@ func SessionRunCommand(serverName string, command string) error {
 		return fmt.Errorf("Server is not running, cannot run \"%s\"", command)
 	}
 
-	cmd := exec.Command("tmux", "send-keys", "-t", sessionName, command, "Enter")
+	cmd := exec.Command("tmux", "send-keys", "-t", sessionName, "-l", command)
+
+	err := cmd.Run()
+
+	if err != nil {
+		return err
+	}
+
+	cmd = exec.Command("tmux", "send-keys", "-t", sessionName, "Enter")
 
 	return cmd.Run()
 }


### PR DESCRIPTION
There was a bug when trying to send command matching reserved keystrokes names such as `end`, which is the commend to stop waterfall. This adds the `-l` argument to pass the command as a literal string, meaning it won't match keystrokes reserved names. That has also the effect of needing a second command to press the `Enter` key, as it is a reserved keystroke.